### PR TITLE
Use propagator wrapper instead of new middleware

### DIFF
--- a/propagator.go
+++ b/propagator.go
@@ -1,0 +1,28 @@
+package otelprofiling
+
+import (
+	"context"
+	"runtime/pprof"
+
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type propagator struct {
+	propagation.TextMapPropagator
+}
+
+func (p propagator) Extract(parent context.Context, carrier propagation.TextMapCarrier) context.Context {
+	ctx := p.TextMapPropagator.Extract(parent, carrier)
+	traceID := trace.SpanContextFromContext(ctx).TraceID().String()
+	ctx = pprof.WithLabels(ctx, pprof.Labels("otel.traceid", traceID))
+	pprof.SetGoroutineLabels(ctx)
+	return ctx
+}
+
+// NewTextMapPropagatorWithProfiling creates a propagator that annotates pprof
+// samples with the otel.traceid label. This allows to establish a relationship
+// between pprof profiles and reported tracing spans.
+func NewTextMapPropagatorWithProfiling(base propagation.TextMapPropagator) propagation.TextMapPropagator {
+	return propagator{TextMapPropagator: base}
+}


### PR DESCRIPTION
Hi @brancz :wave:

I stumbled on this repo, which is really cool, and saw the http/grpc middleware for setting the pprof labels.  I think it can be done in a simpler way using the propagator interface instead, which should work for all of the existing instrumentation libraries.

I didn't remove the existing `otelgrpcprofiling` or `otelhttpprofiling` modules (not sure if you want to deprecate those first), but I can add that if you like the changes.

I didn't test this, but can if you can give me a quick way to do it.