### PR TITLE
Remove dots from label names

### DIFF
--- a/otelgrpcprofiling/grpc.go
+++ b/otelgrpcprofiling/grpc.go
@@ -53,7 +53,7 @@ func (m *Middleware) GrpcUnaryInterceptor(
 		)
 
 		if traceID != "" {
-			pprof.Do(ctx, pprof.Labels("otel.traceid", traceID), func(ctx context.Context) {
+			pprof.Do(ctx, pprof.Labels("otel_traceid", traceID), func(ctx context.Context) {
 				res, err = handler(ctx, req)
 			})
 
@@ -107,7 +107,7 @@ func (m *Middleware) GrpcStreamInterceptor(
 
 			err error
 		)
-		pprof.Do(ctx, pprof.Labels("otel.traceid", traceID), func(ctx context.Context) {
+		pprof.Do(ctx, pprof.Labels("otel_traceid", traceID), func(ctx context.Context) {
 			err = handler(srv, ss)
 		})
 

--- a/otelhttpprofiling/http.go
+++ b/otelhttpprofiling/http.go
@@ -14,7 +14,7 @@ func Handler(h http.Handler) http.Handler {
 		traceID := trace.SpanContextFromContext(ctx).TraceID().String()
 
 		if traceID != "" {
-			pprof.Do(ctx, pprof.Labels("otel.traceid", traceID), func(ctx context.Context) {
+			pprof.Do(ctx, pprof.Labels("otel_traceid", traceID), func(ctx context.Context) {
 				h.ServeHTTP(w, r.WithContext(ctx))
 			})
 			return

--- a/otelprofiling.go
+++ b/otelprofiling.go
@@ -51,7 +51,7 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	}
 
 	if traceID != "" {
-		ctx = pprof.WithLabels(ctx, pprof.Labels("otel.traceid", traceID))
+		ctx = pprof.WithLabels(ctx, pprof.Labels("otel_traceid", traceID))
 		pprof.SetGoroutineLabels(ctx)
 	}
 	return ctx, &s


### PR DESCRIPTION
Parca doesn't like dots, which will change soon, but now that we ingest the label directly instead of transforming it in the agent we should just adapt it to what the tooling supports today.